### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Banshee Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Banshee
+
+Banshee lets you run, orchestrate, and observe CLI agents across providers. The project aims to provide a unified desktop interface for managing agent workflows.
+
+## Architecture
+
+- **Front-end:** React + Vite for the user interface.
+- **Backend:** Tauri with a Rust core to deliver a lightweight, cross-platform desktop app.
+
+## Setup
+
+1. **Prerequisites**
+   - Node.js and npm
+   - Rust toolchain and Tauri prerequisites
+2. **Install**
+   ```bash
+   npm install
+   ```
+3. **Run the web UI**
+   ```bash
+   npm run dev
+   ```
+4. **Run the desktop app**
+   ```bash
+   npm run dev:desktop
+   ```
+5. **Build for production**
+   ```bash
+   npm run build       # web
+   npm run build:desktop  # desktop
+   ```
+
+## Contributing
+
+Contributions are welcome!
+
+1. Fork the repository and create a feature branch.
+2. Install dependencies and run `npm run lint` to ensure code style.
+3. Commit your changes and open a pull request describing your contribution.
+
+By participating, you agree that your contributions will be licensed under the same [MIT license](LICENSE).
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document project goals, architecture, setup, and contribution guidelines in a new README
- add MIT license file and reference it from documentation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba1549be048324bc2b48787f19350d