### PR TITLE
refactor: extract lifecycle and shortcut hooks

### DIFF
--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react'
+import { useSession } from '../state/session'
+
+interface GlobalShortcutsProps {
+  activeProject: any
+  toggleLeftSidebar: () => void
+  toggleRightSidebar: () => void
+}
+
+export function useGlobalShortcuts({ activeProject, toggleLeftSidebar, toggleRightSidebar }: GlobalShortcutsProps) {
+  const sessionStore = useSession()
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!activeProject) return
+
+      if ((e.metaKey || e.ctrlKey) && e.key === 'b') {
+        e.preventDefault()
+        toggleLeftSidebar()
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        toggleRightSidebar()
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === ']') {
+        e.preventDefault()
+        sessionStore.setWorkbenchTab('diffs')
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [activeProject, toggleLeftSidebar, toggleRightSidebar, sessionStore])
+}
+

--- a/src/hooks/useProjectLifecycle.ts
+++ b/src/hooks/useProjectLifecycle.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useCallback } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { useSession } from '../state/session'
+import { useWorkspaceStore } from '../state/workspace'
+
+export function useProjectLifecycle() {
+  const [claudeReady, setClaudeReady] = useState(false)
+  const sessionStore = useSession()
+  const { activeProjectId, getProject } = useWorkspaceStore()
+  const activeProject = activeProjectId ? getProject(activeProjectId) : null
+
+  useEffect(() => {
+    if (activeProject && !sessionStore.projectDir) {
+      sessionStore.setProjectDir(activeProject.path)
+    }
+  }, [activeProject?.path, sessionStore.projectDir])
+
+  const openProject = useCallback(async (path: string) => {
+    setClaudeReady(true)
+
+    const { addProject, setActiveProject, projects } = useWorkspaceStore.getState()
+    const projectName = path.split('/').pop() || path
+
+    const existingProject = projects.find(p => p.path === path)
+    if (existingProject) {
+      setActiveProject(existingProject.id)
+    } else {
+      const projectId = addProject({ name: projectName, path })
+      setActiveProject(projectId)
+    }
+
+    sessionStore.setProjectDir(path)
+
+    Promise.resolve().then(async () => {
+      try {
+        await invoke('start_claude', { projectDir: path })
+      } catch (err) {
+        console.error('Failed to start Claude:', err)
+      }
+    })
+  }, [sessionStore])
+
+  const closeProject = useCallback(async () => {
+    if (claudeReady) {
+      await invoke('stop_claude').catch(console.error)
+    }
+    setClaudeReady(false)
+    sessionStore.setProjectDir(undefined)
+    const { setActiveProject } = useWorkspaceStore.getState()
+    setActiveProject(null)
+  }, [claudeReady, sessionStore])
+
+  useEffect(() => {
+    if (activeProject && !claudeReady) {
+      openProject(activeProject.path)
+    }
+  }, [activeProject?.id, claudeReady, openProject])
+
+  useEffect(() => {
+    return () => {
+      if (claudeReady && (window as any).__TAURI__) {
+        invoke('stop_claude').catch(console.error)
+      }
+    }
+  }, [claudeReady])
+
+  return { activeProject, claudeReady, openProject, closeProject }
+}
+


### PR DESCRIPTION
## Summary
- factor project lifecycle logic into `useProjectLifecycle`
- handle keyboard shortcuts via `useGlobalShortcuts`
- simplify `App.tsx` to focus on layout and routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 276 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba154425388324a8baca7b4aaac132