### PR TITLE
Expose model API configuration via Tauri

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to `.env` and fill in your model credentials
+MODEL_API_ENDPOINT=https://api.example.com
+MODEL_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 # Secrets
 .env
 .env.*
+!.env.example
 repos/.gemini-config
 repos/**/.env
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Banshee
+
+A Tauri + React application.
+
+## Model configuration
+
+Model API credentials can be provided without changing source code. Banshee reads
+model settings from either a `.env` file or from the Tauri configuration and
+exposes them to the React front-end through `@tauri-apps/api`.
+
+### Using `.env`
+
+Create a file named `.env` in the project root:
+
+```
+MODEL_API_ENDPOINT=https://api.example.com
+MODEL_API_KEY=your_api_key
+```
+
+### Using `tauri.conf.json`
+
+Instead of a `.env` file, add a `model` block to
+`src-tauri/tauri.conf.json`:
+
+```
+{
+  ...
+  "model": {
+    "apiEndpoint": "https://api.example.com",
+    "apiKey": "your_api_key"
+  }
+}
+```
+
+During startup the app loads these values and merges them into the user
+settings. They are accessible to the React app via the Tauri command
+`get_model_config`, allowing users to adjust model configuration in the UI
+without editing source files.
+

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,3 +35,4 @@ chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 base64 = "0.22.1"
 dirs = "5.0"
+dotenvy = "0.15"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,5 +43,9 @@
       "qwen-handler.js",
       "codex-handler.js"
     ]
+  },
+  "model": {
+    "apiEndpoint": "https://api.example.com",
+    "apiKey": ""
   }
 }


### PR DESCRIPTION
## Summary
- Load `MODEL_API_KEY` and `MODEL_API_ENDPOINT` from `.env` or `tauri.conf.json`
- Provide `get_model_config` command so React app can merge backend model settings
- Clarify `.env.example` to guide configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 264 errors, 11 warnings)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ba154e8ecc8324a897e87b877b363c