### PR TITLE
chore: add vitest setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "release:mac": "tauri build --bundles dmg",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest",
     "start": "vite"
   },
   "dependencies": {
@@ -55,6 +56,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.0",
-    "vite": "^7.1.0"
+    "vite": "^7.1.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('smoke test', () => {
+  it('runs', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: './',
+  test: {
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vitest in Vite and package scripts
- add simple smoke test

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing dep; numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c6072fc83249165a12cd5f3b8a1