### PR TITLE
Add Monaco editor with Tauri file persistence

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState, useCallback } from 'react'
+import { Editor as MonacoEditor } from '@monaco-editor/react'
+import { invoke } from '@tauri-apps/api/core'
+
+interface EditorProps {
+  path: string
+}
+
+export function Editor({ path }: EditorProps) {
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      if (!('__TAURI__' in window)) return
+      try {
+        const content = await invoke<string>('load_file', { path })
+        if (active) setValue(content)
+      } catch (e) {
+        console.error('Failed to load file', e)
+      }
+    }
+    load()
+    return () => { active = false }
+  }, [path])
+
+  const save = useCallback(async () => {
+    if (!('__TAURI__' in window)) return
+    try {
+      await invoke('save_file', { path, content: value })
+    } catch (e) {
+      console.error('Failed to save file', e)
+    }
+  }, [path, value])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault()
+        save()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [save])
+
+  const language = path.split('.').pop()
+
+  return (
+    <MonacoEditor
+      path={path}
+      theme="vs-dark"
+      language={language}
+      value={value}
+      onChange={v => setValue(v ?? '')}
+      options={{ minimap: { enabled: false } }}
+      height="100%"
+    />
+  )
+}

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -21,6 +21,7 @@ interface FileNode {
 export function FileTree() {
   const projectDir = useSession((s) => s.projectDir)
   const setProjectDir = useSession((s) => s.setProjectDir)
+  const setOpenFile = useSession(s => s.setOpenFile)
   const { activeProjectId, getProject } = useWorkspaceStore()
   const [nodes, setNodes] = useState<FileNode[]>([])
   const [loading, setLoading] = useState(false)
@@ -49,7 +50,7 @@ export function FileTree() {
       addDiagnostic(`Loading directory: ${fullPath}`)
       
       // Step 1: Check Tauri readiness
-      if (!(window as any).__TAURI__) {
+      if (!('__TAURI__' in window)) {
         addDiagnostic('ERROR: Tauri API not available')
         throw new Error('Tauri API not available')
       }
@@ -198,13 +199,13 @@ export function FileTree() {
       const checkAndLoad = async () => {
         // Wait for Tauri to be ready
         let tauriCheckAttempts = 0
-        while (!(window as any).__TAURI__ && tauriCheckAttempts < 50) {
+        while (!('__TAURI__' in window) && tauriCheckAttempts < 50) {
           addDiagnostic(`Waiting for Tauri... attempt ${tauriCheckAttempts + 1}`)
           await new Promise(resolve => setTimeout(resolve, 100))
           tauriCheckAttempts++
         }
         
-        if (!(window as any).__TAURI__) {
+        if (!('__TAURI__' in window)) {
           addDiagnostic('ERROR: Tauri never became available after 5 seconds')
           setLoading(false)
           return
@@ -296,8 +297,7 @@ export function FileTree() {
   // Open file
   function openFile(node: FileNode) {
     if (node.kind === 'file') {
-      // TODO: Implement file opening
-      console.log('Open file:', node.path)
+      setOpenFile(node.path)
     }
   }
 

--- a/src/components/Workbench.tsx
+++ b/src/components/Workbench.tsx
@@ -1,12 +1,27 @@
 import { DiffPanel } from './DiffPanel'
 import { CheckpointsPanel } from './CheckpointsPanel'
+import { Editor } from './Editor'
 import { useSession } from '../state/session'
 
-interface WorkbenchProps {}
-
-export function Workbench({}: WorkbenchProps = {}) {
+export function Workbench() {
   const tab = useSession(s => s.ui.workbenchTab)
   const setTab = useSession(s => s.setWorkbenchTab)
+  const openFile = useSession(s => s.openFile)
+  const setOpenFile = useSession(s => s.setOpenFile)
+  if (openFile) {
+    return (
+      <aside className="workbench">
+        <div className="workbench-tabs">
+          <button className="wb-tab active">{openFile}</button>
+          <button className="wb-tab" onClick={() => setOpenFile(undefined)}>Close</button>
+        </div>
+        <div className="workbench-body">
+          <Editor path={openFile} />
+        </div>
+      </aside>
+    )
+  }
+
   return (
     <aside className="workbench">
       <div className="workbench-tabs">

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -165,6 +165,7 @@ export type SessionState = {
   streamingModel?: string
   streamingMessageId?: string
   pendingProjectDir?: string
+  openFile?: string
   // File tracking for checkpoints
   fileTracker: {
     originalContents: Map<string, string> // Original file contents before AI changes
@@ -183,6 +184,7 @@ export type SessionState = {
   selectEdit: (id?: string) => void
   resolvePermission: (allow: boolean, scope: 'once' | 'session' | 'project') => void
   setWorkbenchTab: (tab: 'diffs' | 'checkpoints') => void
+  setOpenFile: (file?: string) => void
   setShowTerminal: (show: boolean) => void
   setStreaming: (streaming: boolean, model?: string) => void
   clearConversation: () => void
@@ -205,6 +207,7 @@ export const useSession = create<SessionState>((set, get) => {
     isStreaming: false,
     streamingMessageId: undefined,
     pendingProjectDir: undefined,
+    openFile: undefined,
     fileTracker: {
       originalContents: new Map(),
       modifiedFiles: new Set(),
@@ -820,7 +823,7 @@ export const useSession = create<SessionState>((set, get) => {
     const currentDir = get().projectDir
 
     // INSTANT UI UPDATE - Don't block on file I/O
-    set({ projectDir: dir })
+    set({ projectDir: dir, openFile: undefined })
 
     // If switching to a different project, handle clearing/loading
     if (currentDir !== dir) {
@@ -841,7 +844,8 @@ export const useSession = create<SessionState>((set, get) => {
         cost: { usd: 0, tokensIn: 0, tokensOut: 0 },
         isStreaming: false,
         streamingStartTime: undefined,
-        streamingModel: undefined
+        streamingModel: undefined,
+        openFile: undefined
       })
 
       // Load the new project's session asynchronously (non-blocking)
@@ -883,7 +887,9 @@ export const useSession = create<SessionState>((set, get) => {
   },
 
   setWorkbenchTab: (tab) => set((s) => ({ ui: { ...s.ui, workbenchTab: tab } })),
-  
+
+  setOpenFile: (file) => set({ openFile: file }),
+
   setShowTerminal: (show) => set({ showTerminal: show }),
   
   setStreaming: (streaming, model) => {
@@ -1035,6 +1041,7 @@ export const useSession = create<SessionState>((set, get) => {
       streamingStartTime: undefined,
       streamingModel: undefined,
       selectedEditId: undefined,
+      openFile: undefined,
       fileTracker: {
         originalContents: new Map(),
         modifiedFiles: new Set(),


### PR DESCRIPTION
## Summary
- introduce `Editor` component wrapping `monaco-editor` and saving via Tauri
- wire file tree and workbench to open files in the new editor
- add `load_file` and `save_file` commands in Rust for project-scoped file I/O

## Testing
- `npm run lint` *(fails: Empty block statements and type lint errors)*
- `cargo check` *(fails: system library `gobject-2.0`/`glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1662feac8324afeccbe41fe9f95c