### PR TITLE
feat: add keyboard accessible resizers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,7 +99,27 @@ export default function App() {
             <aside className="left-sidebar" id="left-sidebar">
               <FileTree />
             </aside>
-            <div className="resizer" onMouseDown={(e: ReactMouseEvent<HTMLDivElement>) => {
+            <div
+              className="resizer"
+              tabIndex={0}
+              aria-label="Resize left sidebar"
+              onKeyDown={e => {
+                const start = document.documentElement.style.getPropertyValue('--ls-width') || '280px'
+                const current = parseInt(start)
+                const step = 10
+                let next = current
+                if (e.key === 'ArrowLeft') {
+                  next = Math.max(220, current - step)
+                } else if (e.key === 'ArrowRight') {
+                  next = Math.min(480, current + step)
+                } else {
+                  return
+                }
+                document.documentElement.style.setProperty('--ls-width', next + 'px')
+                localStorage.setItem('ls-width', String(next))
+                e.preventDefault()
+              }}
+              onMouseDown={(e: ReactMouseEvent<HTMLDivElement>) => {
               const startX = e.clientX
               const start = document.documentElement.style.getPropertyValue('--ls-width') || '280px'
               const startPx = parseInt(start)
@@ -111,7 +131,8 @@ export default function App() {
               function onUp() { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp) }
               window.addEventListener('mousemove', onMove)
               window.addEventListener('mouseup', onUp)
-            }} />
+            }}
+            />
           </>
         )}
         <div className="chat-container">
@@ -120,7 +141,27 @@ export default function App() {
         </div>
         {rightSidebarOpen && (
           <>
-            <div className="resizer" onMouseDown={(e: ReactMouseEvent<HTMLDivElement>) => {
+            <div
+              className="resizer"
+              tabIndex={0}
+              aria-label="Resize workbench"
+              onKeyDown={e => {
+                const start = document.documentElement.style.getPropertyValue('--wb-width') || '420px'
+                const current = parseInt(start)
+                const step = 10
+                let next = current
+                if (e.key === 'ArrowLeft') {
+                  next = Math.min(640, current + step)
+                } else if (e.key === 'ArrowRight') {
+                  next = Math.max(360, current - step)
+                } else {
+                  return
+                }
+                document.documentElement.style.setProperty('--wb-width', next + 'px')
+                localStorage.setItem('wb-width', String(next))
+                e.preventDefault()
+              }}
+              onMouseDown={(e: ReactMouseEvent<HTMLDivElement>) => {
               const startX = e.clientX
               const start = document.documentElement.style.getPropertyValue('--wb-width') || '420px'
               const startPx = parseInt(start)
@@ -133,7 +174,8 @@ export default function App() {
               function onUp() { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp) }
               window.addEventListener('mousemove', onMove)
               window.addEventListener('mouseup', onUp)
-            }} />
+            }}
+            />
             <Workbench />
           </>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -289,6 +289,9 @@ body {
   background: transparent;
 }
 .resizer:hover { background: var(--accent-bg) }
+.resizer:focus {
+  outline: 2px solid var(--accent);
+}
 
 .workbench-tabs {
   display: flex;


### PR DESCRIPTION
## Summary
- add keyboard controls, ARIA labels, and focus styles for sidebar/workbench resizers
- persist width changes from keyboard interactions to localStorage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ba3e1dedfc8324a002920e60de1e47