### PR TITLE
Sanitize markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cmdk": "^1.1.1",
     "lucide-react": "^0.539.0",
     "marked": "^16.1.2",
+    "dompurify": "^3.1.4",
     "monaco-editor": "^0.52.2",
     "node-pty": "^1.0.0",
     "postcss": "^8.5.6",

--- a/src/components/Message.test.tsx
+++ b/src/components/Message.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { Message } from './Message'
+import type { MessageEvent } from '../state/session'
+
+describe('Message sanitization', () => {
+  const baseMessage: Omit<MessageEvent, 'text'> & { text: string } = {
+    id: '1',
+    type: 'message',
+    role: 'assistant',
+    text: '',
+    ts: 0
+  }
+
+  it('removes script tags from rendered content', () => {
+    const message = { ...baseMessage, text: 'Hello<script>alert(1)</script>' }
+    const html = renderToString(<Message message={message} />)
+    expect(html).not.toContain('<script')
+  })
+
+  it('removes event handler attributes', () => {
+    const message = { ...baseMessage, text: '<img src="x" onerror="alert(1)" />' }
+    const html = renderToString(<Message message={message} />)
+    expect(html).not.toContain('onerror')
+  })
+})

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,6 +1,7 @@
 import { Copy, Check } from 'lucide-react'
 import { useState, useMemo } from 'react'
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import type { MessageEvent } from '../state/session'
  
 interface MessageProps {
@@ -96,10 +97,10 @@ export function Message({ message }: MessageProps) {
           {content.map((part, i) => {
             if (part.type === 'markdown') {
               return (
-                <div 
-                  key={i} 
+                <div
+                  key={i}
                   className="message-text markdown-content"
-                  dangerouslySetInnerHTML={{ __html: marked(part.content) }}
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(part.content)) }}
                 />
               )
             } else if (part.type === 'code') {
@@ -160,10 +161,10 @@ export function Message({ message }: MessageProps) {
         {content.map((part, i) => {
           if (part.type === 'markdown') {
             return (
-              <div 
-                key={i} 
+              <div
+                key={i}
                 className="message-text markdown-content"
-                dangerouslySetInnerHTML={{ __html: marked(part.content) }}
+                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked(part.content)) }}
               />
             )
           } else if (part.type === 'code') {


### PR DESCRIPTION
## Summary
- sanitize rendered markdown with DOMPurify before injecting into the DOM
- add unit tests ensuring script tags and event handlers are stripped from messages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3e1b0d10832494cbf717ec442218