### PR TITLE
feat: add monaco editor with LSP proxy

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,87 @@
+import MonacoEditor, { OnMount } from '@monaco-editor/react'
+import * as monaco from 'monaco-editor'
+import { useEffect, type ClipboardEvent } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { useSettings } from '../state/settings'
+
+interface EditorProps {
+  language: string
+  value: string
+  onChange: (val: string) => void
+  onKeyDown?: (e: monaco.IKeyboardEvent) => void
+  onPaste?: (e: ClipboardEvent<HTMLDivElement>) => void
+  onFocus?: () => void
+  onBlur?: () => void
+}
+
+export function Editor({
+  language,
+  value,
+  onChange,
+  onKeyDown,
+  onPaste,
+  onFocus,
+  onBlur
+}: EditorProps) {
+  const { settings } = useSettings()
+  const lspPath = settings.lspServers?.[language]
+
+  useEffect(() => {
+    if (lspPath) {
+      const initReq = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { capabilities: {}, rootUri: null }
+      }
+      invoke<string>('lsp_proxy', {
+        language,
+        cmd: lspPath,
+        request: JSON.stringify(initReq)
+      }).catch(() => {})
+    }
+  }, [language, lspPath])
+
+  const handleChange = (val?: string) => {
+    const v = val ?? ''
+    onChange(v)
+    if (lspPath) {
+      const didChange = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'textDocument/didChange',
+        params: { text: v }
+      }
+      invoke<string>('lsp_proxy', {
+        language,
+        cmd: lspPath,
+        request: JSON.stringify(didChange)
+      }).catch(() => {})
+    }
+  }
+
+  const handleMount: OnMount = (editor) => {
+    if (onKeyDown) {
+      editor.onKeyDown(onKeyDown)
+    }
+    if (onFocus) {
+      editor.onDidFocusEditorText(onFocus)
+    }
+    if (onBlur) {
+      editor.onDidBlurEditorText(onBlur)
+    }
+  }
+
+  return (
+    <div onPaste={onPaste} style={{ width: '100%' }}>
+      <MonacoEditor
+        height="200px"
+        language={language}
+        value={value}
+        onChange={handleChange}
+        onMount={handleMount}
+        options={{ minimap: { enabled: false } }}
+      />
+    </div>
+  )
+}

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -84,6 +84,9 @@ export interface ClaudeSettings {
     codex?: { binPath?: string; enabled?: boolean; displayMode?: 'clean' | 'compact' | 'verbose'; showReasoning?: boolean }
   }
 
+  // Language servers
+  lspServers?: Record<string, string>
+
   // Common agent behavior toggles
   mcpEnabled?: boolean
   webSearchEnabled?: boolean
@@ -129,6 +132,7 @@ export const useSettings = create<SettingsState>((set, get) => ({
       qwen: { enabled: true },
       codex: { enabled: false, displayMode: 'clean', showReasoning: true }
     },
+    lspServers: {},
     // Preconfigure Claude Code subagents so Claude can delegate
     subAgents: [
       {


### PR DESCRIPTION
## Summary
- add Monaco-based Editor component that proxies changes to language servers
- extend Tauri backend with LSP proxy command and manager
- allow configuring language server binaries via settings
- replace Composer textarea with new Editor

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm test` (fails: vitest not found)
- `cargo test` (fails: glib-2.0 not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba5a5bae50832494c341db6e5e999e