### PR TITLE
fix: lazy load tauri modules to show UI

### DIFF
--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -1,5 +1,4 @@
 import { FolderOpen, GitBranch, Clock, Sparkles, Play } from 'lucide-react'
-import { open } from '@tauri-apps/plugin-dialog'
 import { invoke } from '@tauri-apps/api/core'
 import { useWorkspaceStore } from '../state/workspace'
 import { useState, useEffect } from 'react'
@@ -26,13 +25,15 @@ export function WelcomeView({ onProjectOpen }: { onProjectOpen: (path: string) =
   // No omnibar; actions are presented as simple tiles
 
   const openFolder = async () => {
+    if (!(window as any).__TAURI__) return
     try {
+      const { open } = await import('@tauri-apps/plugin-dialog')
       const selected = await open({
         directory: true,
         multiple: false,
         title: 'Open Project Folder'
       })
-      
+
       if (selected) {
         onProjectOpen(selected as string)
       }
@@ -46,7 +47,9 @@ export function WelcomeView({ onProjectOpen }: { onProjectOpen: (path: string) =
   }
 
   const browseDest = async () => {
+    if (!(window as any).__TAURI__) return
     try {
+      const { open } = await import('@tauri-apps/plugin-dialog')
       const parent = await open({ directory: true, multiple: false, title: 'Choose destination folder' })
       if (parent && typeof parent === 'string') setDestParent(parent)
     } catch (e) { /* ignore */ }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,41 +4,31 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-// Import Tauri APIs to ensure they're loaded
-import '@tauri-apps/api/core'
-import '@tauri-apps/plugin-fs'
-
 // Initialize React app
-function initApp() {
+async function initApp() {
+  if ((window as any).__TAURI__) {
+    await Promise.all([
+      import('@tauri-apps/api/core'),
+      import('@tauri-apps/plugin-fs')
+    ])
+
+    const ls = localStorage.getItem('ls-width')
+    const wb = localStorage.getItem('wb-width')
+    if (ls) document.documentElement.style.setProperty('--ls-width', ls + 'px')
+    if (wb) document.documentElement.style.setProperty('--wb-width', wb + 'px')
+  }
+
   const rootElement = document.getElementById('root')
   if (rootElement) {
-    createRoot(rootElement).render(
-      <App />
-    )
+    createRoot(rootElement).render(<App />)
   }
 }
 
 // Wait for DOM to be ready
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
-    // Initialize app settings (only in Tauri environment)
-    if ((window as any).__TAURI__) {
-      // Restore persisted pane widths
-      const ls = localStorage.getItem('ls-width')
-      const wb = localStorage.getItem('wb-width')
-      if (ls) document.documentElement.style.setProperty('--ls-width', ls + 'px')
-      if (wb) document.documentElement.style.setProperty('--wb-width', wb + 'px')
-    }
     initApp()
   })
 } else {
-  // DOM is already ready
-  if ((window as any).__TAURI__) {
-    // Restore persisted pane widths
-    const ls = localStorage.getItem('ls-width')
-    const wb = localStorage.getItem('wb-width')
-    if (ls) document.documentElement.style.setProperty('--ls-width', ls + 'px')
-    if (wb) document.documentElement.style.setProperty('--wb-width', wb + 'px')
-  }
   initApp()
 }


### PR DESCRIPTION
## Summary
- load Tauri APIs only when running inside Tauri to prevent start-up crashes
- dynamically import dialog plugin in Welcome view

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ba73c2d5c08324b7fee0e2abfb2bcf