### PR TITLE
feat: add codex CLI commands and UI

### DIFF
--- a/src-tauri/src/codex_repo.rs
+++ b/src-tauri/src/codex_repo.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+#[tauri::command]
+pub async fn codex_repo(args: Vec<String>) -> Result<String, String> {
+    let output = tauri::async_runtime::spawn_blocking(move || {
+        Command::new("codex")
+            .arg("repo")
+            .args(&args)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("failed to join codex repo task: {}", e))?
+    .map_err(|e| format!("failed to spawn codex repo: {}", e))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        Err(if stderr.is_empty() {
+            "codex repo failed".into()
+        } else {
+            stderr
+        })
+    }
+}
+

--- a/src-tauri/src/codex_run.rs
+++ b/src-tauri/src/codex_run.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+#[tauri::command]
+pub async fn codex_run(args: Vec<String>) -> Result<String, String> {
+    let output = tauri::async_runtime::spawn_blocking(move || {
+        Command::new("codex")
+            .arg("run")
+            .args(&args)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("failed to join codex run task: {}", e))?
+    .map_err(|e| format!("failed to spawn codex run: {}", e))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        Err(if stderr.is_empty() {
+            "codex run failed".into()
+        } else {
+            stderr
+        })
+    }
+}
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,11 @@ use terminal::{LspManager, TerminalManager};
 mod checkpoint;
 use checkpoint::*;
 
+mod codex_repo;
+mod codex_run;
+use codex_repo::codex_repo;
+use codex_run::codex_run;
+
 trait ModelHandler: Send {
     fn start(&mut self, app: tauri::AppHandle, project_dir: &str) -> Result<(), String>;
     fn send(&mut self, input: &str) -> Result<(), String>;
@@ -684,7 +689,9 @@ pub fn run() {
             clean_old_checkpoints,
             list_checkpoints,
             save_temp_image,
-            clone_repo
+            clone_repo,
+            codex_repo,
+            codex_run
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/CodexPanel.tsx
+++ b/src/components/CodexPanel.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+
+export function CodexPanel() {
+  const [repoArgs, setRepoArgs] = useState('')
+  const [repoOutput, setRepoOutput] = useState('')
+  const [runArgs, setRunArgs] = useState('')
+  const [runOutput, setRunOutput] = useState('')
+
+  const handleRepo = async () => {
+    try {
+      const args = repoArgs.trim() ? repoArgs.split(/\s+/) : []
+      const result = await invoke<string>('codex_repo', { args })
+      setRepoOutput(result)
+    } catch (e) {
+      setRepoOutput(String(e))
+    }
+  }
+
+  const handleRun = async () => {
+    try {
+      const args = runArgs.trim() ? runArgs.split(/\s+/) : []
+      const result = await invoke<string>('codex_run', { args })
+      setRunOutput(result)
+    } catch (e) {
+      setRunOutput(String(e))
+    }
+  }
+
+  return (
+    <div className="codex-panel">
+      <section>
+        <h3>Codex Repo</h3>
+        <div className="codex-control">
+          <input
+            value={repoArgs}
+            onChange={e => setRepoArgs(e.target.value)}
+            placeholder="arguments"
+          />
+          <button onClick={handleRepo}>Run</button>
+        </div>
+        {repoOutput && <pre className="codex-output">{repoOutput}</pre>}
+      </section>
+      <section>
+        <h3>Codex Run</h3>
+        <div className="codex-control">
+          <input
+            value={runArgs}
+            onChange={e => setRunArgs(e.target.value)}
+            placeholder="arguments"
+          />
+          <button onClick={handleRun}>Run</button>
+        </div>
+        {runOutput && <pre className="codex-output">{runOutput}</pre>}
+      </section>
+    </div>
+  )
+}
+
+export default CodexPanel
+

--- a/src/components/Workbench.tsx
+++ b/src/components/Workbench.tsx
@@ -1,5 +1,6 @@
 import { DiffPanel } from './DiffPanel'
 import { CheckpointsPanel } from './CheckpointsPanel'
+import { CodexPanel } from './CodexPanel'
 import { useSession } from '../state/session'
 
 interface WorkbenchProps {}
@@ -18,9 +19,13 @@ export function Workbench({}: WorkbenchProps = {}) {
           className={`wb-tab ${tab === 'checkpoints' ? 'active' : ''}`}
           onClick={() => setTab('checkpoints')}
         >Checkpoints</button>
+        <button
+          className={`wb-tab ${tab === 'codex' ? 'active' : ''}`}
+          onClick={() => setTab('codex')}
+        >Codex</button>
       </div>
       <div className="workbench-body">
-        {tab === 'diffs' ? <DiffPanel /> : <CheckpointsPanel />}
+        {tab === 'diffs' ? <DiffPanel /> : tab === 'checkpoints' ? <CheckpointsPanel /> : <CodexPanel />}
       </div>
     </aside>
   )

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -172,7 +172,7 @@ export type SessionState = {
     isTracking: boolean
   }
   ui: {
-    workbenchTab: 'diffs' | 'checkpoints'
+    workbenchTab: 'diffs' | 'checkpoints' | 'codex'
   }
 
   pushEvent: (e: SessionEvent) => void
@@ -182,7 +182,7 @@ export type SessionState = {
   rejectEdit: (id: string) => void
   selectEdit: (id?: string) => void
   resolvePermission: (allow: boolean, scope: 'once' | 'session' | 'project') => void
-  setWorkbenchTab: (tab: 'diffs' | 'checkpoints') => void
+  setWorkbenchTab: (tab: 'diffs' | 'checkpoints' | 'codex') => void
   setShowTerminal: (show: boolean) => void
   setStreaming: (streaming: boolean, model?: string) => void
   clearConversation: () => void


### PR DESCRIPTION
## Summary
- add Tauri commands for `codex repo` and `codex run`
- expose Codex controls in a new workbench panel
- extend session state to support Codex tab

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba97b7b87483249abc0ee2e589371c