### PR TITLE
Make terminal commands asynchronous

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -316,7 +316,7 @@ struct CommandResult {
 }
 
 #[tauri::command]
-fn run_command(command: String, cwd: Option<String>) -> Result<CommandResult, String> {
+async fn run_command(command: String, cwd: Option<String>) -> Result<CommandResult, String> {
     use std::env;
 
     let working_dir = cwd.unwrap_or_else(|| {
@@ -364,13 +364,21 @@ fn run_command(command: String, cwd: Option<String>) -> Result<CommandResult, St
         (working_dir.clone(), command.as_str())
     };
 
+    let working_dir_for_spawn = working_dir.clone();
+    let new_cwd_for_spawn = new_cwd.clone();
+    let actual_command_owned = actual_command.to_string();
+
     // Execute the command
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(actual_command)
-        .current_dir(&working_dir)
-        .output()
-        .map_err(|e| format!("Failed to execute command: {}", e))?;
+    let output = tauri::async_runtime::spawn_blocking(move || {
+        Command::new("sh")
+            .arg("-c")
+            .arg(actual_command_owned)
+            .current_dir(&working_dir_for_spawn)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("Failed to join command task: {}", e))?
+    .map_err(|e| format!("Failed to execute command: {}", e))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -387,24 +395,33 @@ fn run_command(command: String, cwd: Option<String>) -> Result<CommandResult, St
     Ok(CommandResult {
         output: combined_output,
         exit_code,
-        cwd: new_cwd,
+        cwd: new_cwd_for_spawn,
     })
 }
 
 #[tauri::command]
-fn execute_command(command: String) -> Result<String, String> {
+async fn execute_command(command: String) -> Result<String, String> {
     let project_dir = PROJECT_DIR.lock().unwrap().clone();
 
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(&command)
-        .current_dir(if project_dir.is_empty() {
-            "."
-        } else {
-            &project_dir
-        })
-        .output()
-        .map_err(|e| format!("Failed to execute command: {}", e))?;
+    let working_dir = if project_dir.is_empty() {
+        String::from(".")
+    } else {
+        project_dir.clone()
+    };
+
+    let command_owned = command.clone();
+    let working_dir_for_spawn = working_dir.clone();
+
+    let output = tauri::async_runtime::spawn_blocking(move || {
+        Command::new("sh")
+            .arg("-c")
+            .arg(command_owned)
+            .current_dir(&working_dir_for_spawn)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("Failed to join command task: {}", e))?
+    .map_err(|e| format!("Failed to execute command: {}", e))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();


### PR DESCRIPTION
## Summary
- convert the `run_command` and `execute_command` tauri commands to async functions so they can await blocking work
- move the blocking shell invocations into `tauri::async_runtime::spawn_blocking` with owned command and directory strings

## Testing
- npm run test -- --run *(fails: DOMPurify.sanitize is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68d88b656b5c832493d0b9263f3fcfa7