### PR TITLE
Handle array responses from folder dialog selections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,10 @@ export default function App() {
       })
 
       if (selected) {
-        openProject(selected as string)
+        const folderPath = Array.isArray(selected) ? selected[0] : selected
+        if (typeof folderPath === 'string' && folderPath.length > 0) {
+          await openProject(folderPath)
+        }
       }
     } catch (err) {
       console.error('Failed to open folder:', err)

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -51,9 +51,12 @@ export function FileTree() {
     try {
       const { open } = await import('@tauri-apps/plugin-dialog')
       const selected = await open({ directory: true, multiple: false, title: 'Open Repository' })
-      if (!selected || typeof selected !== 'string') return
+      if (!selected) return
 
-      const repoPath = selected as string
+      const repoPathCandidate = Array.isArray(selected) ? selected[0] : selected
+      if (typeof repoPathCandidate !== 'string' || repoPathCandidate.length === 0) return
+
+      const repoPath = repoPathCandidate
       const projectName = repoPath.split('/').pop() || repoPath
 
       const workspace = useWorkspaceStore.getState()

--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -35,7 +35,10 @@ export function WelcomeView({ onProjectOpen }: { onProjectOpen: (path: string) =
       })
 
       if (selected) {
-        onProjectOpen(selected as string)
+        const folderPath = Array.isArray(selected) ? selected[0] : selected
+        if (typeof folderPath === 'string' && folderPath.length > 0) {
+          onProjectOpen(folderPath)
+        }
       }
     } catch (err) {
       console.error('Failed to open folder:', err)


### PR DESCRIPTION
## Summary
- normalize folder selections returned from the Tauri folder picker before opening projects
- guard the file tree repository opener to ensure a valid string path is passed to workspace/session stores

## Testing
- npm run lint *(fails: existing lint violations in project)*

------
https://chatgpt.com/codex/tasks/task_e_68d88e9a86308324988922ce8f649be3