### PR TITLE
Robustly normalize dialog selections before opening projects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { useProjectLifecycle } from './hooks/useProjectLifecycle'
 import { useGlobalShortcuts } from './hooks/useGlobalShortcuts'
 import { SettingsView } from './components/SettingsView'
 import { useSettings } from './state/settings'
+import { normalizeDialogSelection } from './utils/dialog'
 
 function useCssWidth(key: string, fallback: number) {
   const [width, setWidth] = useState(() => {
@@ -74,8 +75,9 @@ export default function App() {
         title: 'Open Project Folder'
       })
 
-      if (selected) {
-        openProject(selected as string)
+      const folderPath = normalizeDialogSelection(selected)
+      if (folderPath) {
+        await openProject(folderPath)
       }
     } catch (err) {
       console.error('Failed to open folder:', err)

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -9,6 +9,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { path } from '@tauri-apps/api'
 import { runTauriFileSystemDiagnostics, formatDiagnosticResults } from '../utils/tauriDiagnostics'
 import { getGitStatus, type GitFileStatus } from '../utils/gitStatus'
+import { normalizeDialogSelection } from '../utils/dialog'
 import { Tooltip } from './Tooltip'
 
 interface FileNode {
@@ -51,9 +52,8 @@ export function FileTree() {
     try {
       const { open } = await import('@tauri-apps/plugin-dialog')
       const selected = await open({ directory: true, multiple: false, title: 'Open Repository' })
-      if (!selected || typeof selected !== 'string') return
-
-      const repoPath = selected as string
+      const repoPath = normalizeDialogSelection(selected)
+      if (!repoPath) return
       const projectName = repoPath.split('/').pop() || repoPath
 
       const workspace = useWorkspaceStore.getState()

--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -2,6 +2,7 @@ import { FolderOpen, GitBranch, Clock, Sparkles, Play } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { useWorkspaceStore } from '../state/workspace'
 import { useState, useEffect } from 'react'
+import { normalizeDialogSelection } from '../utils/dialog'
 
 export function WelcomeView({ onProjectOpen }: { onProjectOpen: (path: string) => void }) {
   const { recentProjects } = useWorkspaceStore()
@@ -34,8 +35,9 @@ export function WelcomeView({ onProjectOpen }: { onProjectOpen: (path: string) =
         title: 'Open Project Folder'
       })
 
-      if (selected) {
-        onProjectOpen(selected as string)
+      const folderPath = normalizeDialogSelection(selected)
+      if (folderPath) {
+        onProjectOpen(folderPath)
       }
     } catch (err) {
       console.error('Failed to open folder:', err)

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -1,0 +1,46 @@
+export function normalizeDialogSelection(selection: unknown): string | null {
+  if (selection == null) {
+    return null
+  }
+
+  if (Array.isArray(selection)) {
+    for (const value of selection) {
+      const normalized = normalizeDialogSelection(value)
+      if (normalized) return normalized
+    }
+    return null
+  }
+
+  if (typeof selection === 'string') {
+    const trimmed = selection.trim()
+    if (!trimmed) {
+      return null
+    }
+
+    const firstChar = trimmed[0]
+    const lastChar = trimmed[trimmed.length - 1]
+    const looksJsonContainer = (firstChar === '[' && lastChar === ']') || (firstChar === '{' && lastChar === '}')
+    if (looksJsonContainer) {
+      try {
+        return normalizeDialogSelection(JSON.parse(trimmed))
+      } catch {
+        // Fall through to returning the raw string when JSON parsing fails
+      }
+    }
+
+    return trimmed
+  }
+
+  if (typeof selection === 'object') {
+    const candidate = (selection as { path?: unknown; paths?: unknown }).path
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+
+    if ('paths' in (selection as object)) {
+      return normalizeDialogSelection((selection as { paths?: unknown }).paths)
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- add a dialog selection normalizer that resolves strings, arrays, JSON payloads, and object responses into a folder path
- use the normalizer wherever folders are opened so only valid string paths reach the project lifecycle flows

## Testing
- npm run lint *(fails: pre-existing lint violations across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d88e9a86308324988922ce8f649be3